### PR TITLE
DropdownControls component exported from the datagrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 * Update Wizard styles and add possibility to hide page indicator
 * Add Inspector icon
 
+## 4.0.1
+
+* DropdownControls component exported from the datagrid
+* README.md modified
+
 ## 4.0.0
 
 * Remove react-router dependency from responsive-navbar and menu

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Some components needs reducers to be loaded in the redux store, those are done i
 ### Development workflow with project using the package
 ##### Link local package to your project
 * Run `npm link` at `oc-common-ui` root to make your local package linkable
-* Run `npm link oc-common-ui` at project's dir that's using `oc-common-ui` to use local package
+* Run `npm link @opuscapita/oc-common-ui` at project's dir that's using `oc-common-ui` to use local package
 ##### Build and watch the package
 * Run `npm run dev` to run webpack in watch mode
 ##### Unlink local package
-* Run `npm unlink oc-common-ui` at project's dir that's using `oc-common-ui`
+* Run `npm unlink @opuscapita/oc-common-ui` at project's dir that's using `oc-common-ui`
 * Run `npm install` to install remote copy of the `oc-common-ui` package
 
 ### Changelog

--- a/src/datagrid/index.js
+++ b/src/datagrid/index.js
@@ -1,3 +1,4 @@
 export Datagrid from './datagrid.component';
+export DropdownControls from './dropdown-controls.component';
 export datagridReducer from './datagrid.reducer';
 export * as DatagridActions from './datagrid.actions';


### PR DESCRIPTION
DropdownControls is used by the oc-mathcing-ui directly and needs to be exposed.