### PR TITLE
Datagrid's editing mode changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add `disableActionSave` prop to `Datagrid`
 * Combine error and warning status for cells with 'error' type prioritized in `Datagrid`
 * Add grey corner to edited cells of `Datagrid`
+* Add navigation between cells of `Datagrid` with arrow keys in editing mode
 
 ## 4.1.3
 * fix to datagrid's scroll to row functionality

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## <next>
-* Add `disableActionsMessage` prop to `Datagrid`
-* Fix datagrid filtering when component type is select, show exact matches only.
-* Increase Alert component z-index value to keep it at top of other elements like scrollbars.
+* Add `disableActionsMessage` prop to `Datagrid` to display over disabled actions
+* Fix datagrid filtering when component type is select, show exact matches only
+* Increase Alert component z-index value to keep it at top of other elements like scrollbars
+* Add `disableActionSave` prop to `Datagrid`
+* Combine error and warning status for cells with 'error' type prioritized in `Datagrid`
+* Add grey corner to edited cells of `Datagrid`
 
 ## 4.1.3
 * fix to datagrid's scroll to row functionality

--- a/examples/components/datagrid/datagrid.component.jsx
+++ b/examples/components/datagrid/datagrid.component.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { List } from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';

--- a/examples/components/datagrid/datagrid.component.jsx
+++ b/examples/components/datagrid/datagrid.component.jsx
@@ -97,12 +97,13 @@ export default class DatagridView extends React.Component {
         <Datagrid
           id={GRID_ID}
           idKeyPath={['accountId']}
+          allowArrowNavigationEdit
           columns={columns}
           disableActionSave={this.props.isEditing && this.props.dataEdited.size === 0}
-          inlineEdit
-          rowSelect
-          multiSelect
           filtering
+          inlineEdit
+          multiSelect
+          rowSelect
           rowSelectCheckboxColumn
         />
       </div>

--- a/examples/components/datagrid/datagrid.component.jsx
+++ b/examples/components/datagrid/datagrid.component.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { List } from 'immutable';
+import { List, Map } from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
 import { Datagrid, DatagridActions } from '../../../src/index';
@@ -17,14 +17,18 @@ const mapDispatchToProps = {
 
 const mapStateToProps = state => ({
   data: state.datagrid.getIn([GRID_ID, 'data'], List()),
+  dataEdited: state.datagrid.getIn([GRID_ID, 'editData'], Map()),
+  isEditing: state.datagrid.getIn([GRID_ID, 'session', 'isEditing'], false),
 });
 
 @connect(mapStateToProps, mapDispatchToProps)
 export default class DatagridView extends React.Component {
   static propTypes = {
     data: ImmutablePropTypes.list.isRequired,
+    dataEdited: ImmutablePropTypes.map.isRequired,
     datagridCellShowMessage: PropTypes.func.isRequired,
     datagridSetData: PropTypes.func.isRequired,
+    isEditing: PropTypes.bool.isRequired,
   };
 
   componentWillMount() {
@@ -94,11 +98,12 @@ export default class DatagridView extends React.Component {
           id={GRID_ID}
           idKeyPath={['accountId']}
           columns={columns}
+          disableActionSave={this.props.isEditing && this.props.dataEdited.size === 0}
+          inlineEdit
           rowSelect
           multiSelect
           filtering
           rowSelectCheckboxColumn
-          inlineEdit
         />
       </div>
     );

--- a/examples/components/datagrid/datagrid.component.jsx
+++ b/examples/components/datagrid/datagrid.component.jsx
@@ -97,9 +97,9 @@ export default class DatagridView extends React.Component {
         <Datagrid
           id={GRID_ID}
           idKeyPath={['accountId']}
-          allowArrowNavigationEdit
           columns={columns}
           disableActionSave={this.props.isEditing && this.props.dataEdited.size === 0}
+          enableArrowNavigation
           filtering
           inlineEdit
           multiSelect

--- a/examples/components/datagrid/datagrid.component.jsx
+++ b/examples/components/datagrid/datagrid.component.jsx
@@ -1,27 +1,39 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { List } from 'immutable';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+
 import { Datagrid, DatagridActions } from '../../../src/index';
 import { bankAccountData } from './data';
 import './datagrid.component.scss';
 
-// TODO: Expand example to have inline edit etc..
-
 const GRID_ID = 'accounts-grid-example';
 
 const mapDispatchToProps = {
+  datagridCellShowMessage: DatagridActions.cellShowMessage,
   datagridSetData: DatagridActions.setData,
 };
 
-const mapStateToProps = () => ({});
+const mapStateToProps = state => ({
+  data: state.datagrid.getIn([GRID_ID, 'data'], List()),
+});
 
 @connect(mapStateToProps, mapDispatchToProps)
 export default class DatagridView extends React.Component {
   static propTypes = {
+    data: ImmutablePropTypes.list.isRequired,
+    datagridCellShowMessage: PropTypes.func.isRequired,
     datagridSetData: PropTypes.func.isRequired,
   };
 
   componentWillMount() {
     this.props.datagridSetData(GRID_ID, bankAccountData);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.data.size !== this.props.data.size) {
+      this.props.datagridCellShowMessage(GRID_ID, 'warning', 1, ['name'], 'WarningExample');
+    }
   }
 
   render() {
@@ -31,6 +43,9 @@ export default class DatagridView extends React.Component {
         valueKeyPath: ['name'],
         valueType: 'text',
         componentType: 'text',
+        validators: [
+          { unique: true },
+        ],
         width: 200,
       },
       {
@@ -82,6 +97,7 @@ export default class DatagridView extends React.Component {
           multiSelect
           filtering
           rowSelectCheckboxColumn
+          inlineEdit
         />
       </div>
     );

--- a/src/constants/key-codes.constant.js
+++ b/src/constants/key-codes.constant.js
@@ -1,5 +1,9 @@
 const KEY_CODES = {
   ENTER: 13,
+  LEFT: 37,
+  UP: 38,
+  RIGHT: 39,
+  DOWN: 40,
 };
 
 export default KEY_CODES;

--- a/src/datagrid/README.md
+++ b/src/datagrid/README.md
@@ -35,11 +35,11 @@ rowSelect | boolean | false | Enable row selecting
 rowSelectCheckboxColumn | boolean | false | Enable additional checkbox column for row selecting
 multiSelect | boolean | false | Enable multi selecting on row selecting
 selectComponentOptions | Immutable.Map | | Options data for the react-select components
-allowArrowNavigationEdit | boolean | false | Allow navigation with arrow keys in editing mode
 disableActions | boolean | false | Disable action bar actions, eg. when other grid busy
 disableActionsMessage | string | 'GridActionsDisabledOtherGridBusy' | Message about the reason of disabled action bar actions
 disableActionBar | boolean | false | Disable action bar rendering
 disableActionSave | boolean | false | Disable Save action button
+enableArrowNavigation | boolean | false | Allow navigation with arrow keys in editing mode
 onSave | function | | Callback that is called when save button is clicked
 onRemove | function | | Callback that is called when delete is clicked
 onCancel | function | | Callback that is called when cancel is clicked

--- a/src/datagrid/README.md
+++ b/src/datagrid/README.md
@@ -39,7 +39,7 @@ disableActions | boolean | false | Disable action bar actions, eg. when other gr
 disableActionsMessage | string | 'GridActionsDisabledOtherGridBusy' | Message about the reason of disabled action bar actions
 disableActionBar | boolean | false | Disable action bar rendering
 disableActionSave | boolean | false | Disable Save action button
-enableArrowNavigation | boolean | false | Allow navigation with arrow keys in editing mode
+enableArrowNavigation | boolean | false | Enable navigation with arrow keys in editing mode
 onSave | function | | Callback that is called when save button is clicked
 onRemove | function | | Callback that is called when delete is clicked
 onCancel | function | | Callback that is called when cancel is clicked

--- a/src/datagrid/README.md
+++ b/src/datagrid/README.md
@@ -35,6 +35,7 @@ rowSelect | boolean | false | Enable row selecting
 rowSelectCheckboxColumn | boolean | false | Enable additional checkbox column for row selecting
 multiSelect | boolean | false | Enable multi selecting on row selecting
 selectComponentOptions | Immutable.Map | | Options data for the react-select components
+allowArrowNavigationEdit | boolean | false | Allow navigation with arrow keys in editing mode
 disableActions | boolean | false | Disable action bar actions, eg. when other grid busy
 disableActionsMessage | string | 'GridActionsDisabledOtherGridBusy' | Message about the reason of disabled action bar actions
 disableActionBar | boolean | false | Disable action bar rendering

--- a/src/datagrid/README.md
+++ b/src/datagrid/README.md
@@ -38,6 +38,7 @@ selectComponentOptions | Immutable.Map | | Options data for the react-select com
 disableActions | boolean | false | Disable action bar actions, eg. when other grid busy
 disableActionsMessage | string | 'GridActionsDisabledOtherGridBusy' | Message about the reason of disabled action bar actions
 disableActionBar | boolean | false | Disable action bar rendering
+disableActionSave | boolean | false | Disable Save action button
 onSave | function | | Callback that is called when save button is clicked
 onRemove | function | | Callback that is called when delete is clicked
 onCancel | function | | Callback that is called when cancel is clicked

--- a/src/datagrid/cell-tooltip.component.jsx
+++ b/src/datagrid/cell-tooltip.component.jsx
@@ -59,8 +59,7 @@ export default class DatagridTooltip extends React.Component {
       let tooltipClassName = 'tooltip';
       if (isError) {
         tooltipClassName = 'error tooltip';
-      }
-      if (isWarning) {
+      } else if (isWarning) {
         tooltipClassName = 'warning tooltip';
       }
       overlayAttrs = {
@@ -75,7 +74,7 @@ export default class DatagridTooltip extends React.Component {
     const wrapperClassName = classNames({
       'oc-datagrid-tooltip': true,
       error: isError,
-      warning: isWarning,
+      warning: isWarning && !isError,
     });
     return (
       <OverlayTrigger {...overlayAttrs}>

--- a/src/datagrid/cell-tooltip.component.jsx
+++ b/src/datagrid/cell-tooltip.component.jsx
@@ -13,6 +13,7 @@ export default class DatagridTooltip extends React.Component {
       PropTypes.number,
     ]).isRequired,
     children: PropTypes.node,
+    isEdited: PropTypes.bool,
     isError: PropTypes.bool,
     isWarning: PropTypes.bool,
     messageId: PropTypes.string,
@@ -25,6 +26,7 @@ export default class DatagridTooltip extends React.Component {
 
   static defaultProps = {
     children: null,
+    isEdited: false,
     isError: false,
     isWarning: false,
     messageId: null,
@@ -39,6 +41,7 @@ export default class DatagridTooltip extends React.Component {
     const {
       children,
       id,
+      isEdited,
       isError,
       isWarning,
       messageId,
@@ -73,6 +76,7 @@ export default class DatagridTooltip extends React.Component {
     }
     const wrapperClassName = classNames({
       'oc-datagrid-tooltip': true,
+      edited: isEdited,
       error: isError,
       warning: isWarning && !isError,
     });

--- a/src/datagrid/datagrid.component.jsx
+++ b/src/datagrid/datagrid.component.jsx
@@ -1193,6 +1193,17 @@ export default class DataGrid extends React.PureComponent {
     return columns;
   }
 
+  isCellEdited = (rowIndex, col, cellType) => {
+    if (cellType !== 'edit') {
+      return false;
+    }
+    const id = this.getDataIdByRowIndex(rowIndex);
+    if (this.props.editData.getIn([id, ...col.valueKeyPath])) {
+      return true;
+    }
+    return false;
+  }
+
   // checker for selectionCheckbox
   isSelectionCheckbox(cellProps) {
     const expectedColumnKey = 'selectionCheckbox';
@@ -1239,10 +1250,12 @@ export default class DataGrid extends React.PureComponent {
     if ((cellType === 'view' || cellType === 'edit' || cellType === 'create') && !isCheckbox) {
       const getRowIndex = (cellType === 'create') ? rowIndex : (rowIndex - extraRowCount);
       const messageData = this.getCellMessages(getRowIndex, col, cellType);
+      const isEdited = this.isCellEdited(getRowIndex, col, cellType);
       return (
         <Cell {...props} className="oc-datagrid-cell" style={style}>
           <CellTooltip
             id={cellType + col.columnKey + (rowIndex - extraRowCount)}
+            isEdited={isEdited}
             isError={!!messageData.errorMessageId}
             isWarning={!!messageData.warningMessageId}
             errorMessageId={messageData.errorMessageId}

--- a/src/datagrid/datagrid.component.jsx
+++ b/src/datagrid/datagrid.component.jsx
@@ -141,6 +141,7 @@ const mapDispatchToProps = datagridActions;
  * @prop {boolean} propTypes.disableActions - Disable action bar actions, eg. when other grid busy
  * @prop {string} propTypes.disableActionsMessage - Message about the reason of disabled action bar actions
  * @prop {boolean} propTypes.disableActionBar - Disable action bar rendering
+ * @prop {boolean} propTypes.disableActionSave - Disable Save action of action bar
  * @prop {function} propTypes.onSave - Callback that is called when save button is clicked
  * @prop {function} propTypes.onRemove - Callback that is called when delete is clicked
  * @prop {function} propTypes.onCancel - Callback that is called when cancel is clicked
@@ -287,6 +288,7 @@ export default class DataGrid extends React.PureComponent {
     disableActions: PropTypes.bool,               // Disable actions in the action bar
     disableActionsMessage: PropTypes.string,
     disableActionBar: PropTypes.bool,
+    disableActionSave: PropTypes.bool,
     onSave: PropTypes.func,
     onRemove: PropTypes.func,
     onCancel: PropTypes.func,
@@ -316,6 +318,7 @@ export default class DataGrid extends React.PureComponent {
   static defaultProps = {
     children: undefined,
     containerStyle: {},
+    disableActionSave: false,
     headerHeight: 40,
     rowHeight: 40,
     onSave: () => {},

--- a/src/datagrid/datagrid.component.jsx
+++ b/src/datagrid/datagrid.component.jsx
@@ -332,7 +332,7 @@ export default class DataGrid extends React.PureComponent {
 
   constructor(props) {
     super(props);
-    this.state = { scrollToRow: 0, scrollToColumn: 0 };
+    this.state = { currentRow: 0, currentColumn: 0 };
   }
 
   componentWillMount() {
@@ -607,13 +607,13 @@ export default class DataGrid extends React.PureComponent {
 
   moveCellFocus = (nextElement, rowIndex, columnIndex) => {
     if (nextElement && nextElement.type === 'text') {
-      setTimeout(() => nextElement.select(), 50);
       if (rowIndex !== -1) {
-        this.setState({ scrollToRow: rowIndex });
+        this.setState({ currentRow: rowIndex });
       }
       if (columnIndex !== -1) {
-        this.setState({ scrollToColumn: columnIndex });
+        this.setState({ currentColumn: columnIndex + 1 });
       }
+      setTimeout(() => nextElement.select(), 50);
     }
   }
 
@@ -1465,10 +1465,8 @@ export default class DataGrid extends React.PureComponent {
                     this.props.data.size;
     if (this.props.isCreating) rowsCount += this.props.createData.size;
     if (this.props.isFiltering) rowsCount += 1;
-    let scrollToRow = this.props.scrollToRow;
-    if (!scrollToRow && this.state.scrollToRow > 0) {
-      scrollToRow = this.state.scrollToRow;
-    } else if (!scrollToRow && this.props.selectedItems.size > 0) {
+    let scrollToRow = this.props.scrollToRow || this.state.currentRow;
+    if (!scrollToRow && this.props.selectedItems.size > 0) {
       scrollToRow = this.getSelectedItemIndex(this.props.selectedItems.first());
     }
     return (
@@ -1511,7 +1509,7 @@ export default class DataGrid extends React.PureComponent {
             }
             return true;
           }}
-          scrollToColumn={this.props.scrollToColumn || this.state.scrollToColumn}
+          scrollToColumn={this.props.scrollToColumn || this.state.currentColumn}
           scrollTop={this.props.scrollTop}
           scrollToRow={scrollToRow}
           onRowDoubleClick={this.props.onRowDoubleClick}

--- a/src/datagrid/datagrid.component.scss
+++ b/src/datagrid/datagrid.component.scss
@@ -175,17 +175,17 @@ $oc-color-grid-warning: $oc-color-yellow;
       }
     }
     &.warning {
-      &:after {
+      &:before {
         display: block;
         content: "";
         position: absolute;
         right: 0;
-        bottom: 0;
+        top: 0;
         border-color: transparent;
         border-style: solid;
         border-width: 7px;
         border-right-color: $oc-color-grid-warning;
-        border-bottom-color: $oc-color-grid-warning;
+        border-top-color: $oc-color-grid-warning;
         z-index: 100000;
       }
     }

--- a/src/datagrid/datagrid.component.scss
+++ b/src/datagrid/datagrid.component.scss
@@ -189,6 +189,21 @@ $oc-color-grid-warning: $oc-color-yellow;
         z-index: 100000;
       }
     }
+    &.edited {
+      &:after {
+        display: block;
+        content: "";
+        position: absolute;
+        right: 0;
+        bottom: 0;
+        border-color: transparent;
+        border-style: solid;
+        border-width: 7px;
+        border-right-color: $oc-color-support-gray;
+        border-bottom-color: $oc-color-support-gray;
+        z-index: 100000;
+      }
+    }
   }
 
 }

--- a/src/datagrid/inline-edit-controls.component.jsx
+++ b/src/datagrid/inline-edit-controls.component.jsx
@@ -29,6 +29,7 @@ export default class InlineEditControls extends React.PureComponent {
     onAddClick: PropTypes.func,
     disableActions: PropTypes.bool,
     disableActionsMessage: PropTypes.string,
+    disableActionSave: PropTypes.bool,
     inlineAdd: PropTypes.bool,
     tabIndex: PropTypes.number,
   };
@@ -36,6 +37,7 @@ export default class InlineEditControls extends React.PureComponent {
   static defaultProps = {
     disableActions: false,
     disableActionsMessage: 'GridActionsDisabledOtherGridBusy',
+    disableActionSave: false,
     inlineAdd: true,
     idKeyPath: [],
     firstInvalidInput: null,
@@ -88,31 +90,42 @@ export default class InlineEditControls extends React.PureComponent {
   }
 
   render() {
-    if (this.props.isCreating || this.props.isEditing) {
+    const {
+      disableActions,
+      disableActionsMessage,
+      disableActionSave,
+      id,
+      inlineAdd,
+      isBusy,
+      isCreating,
+      isEditing,
+      tabIndex,
+    } = this.props;
+    if (isCreating || isEditing) {
       return (
         <div className="oc-datagrid-inline-edit-controls">
           <Button
-            disabled={this.props.isBusy || this.props.disableActions}
+            disabled={isBusy || disableActions || disableActionSave}
             onClick={this.handleSaveButtonClick}
-            tabIndex={this.props.tabIndex + 1}
-            id={`oc-datagrid-controls-save-${this.props.id}`}
+            tabIndex={tabIndex + 1}
+            id={`oc-datagrid-controls-save-${id}`}
           >
             <M id="Save" />
           </Button>
           <Button
-            disabled={this.props.isBusy || this.props.disableActions}
+            disabled={isBusy || disableActions}
             onClick={this.handleCancelButtonClick}
-            tabIndex={this.props.tabIndex + 2}
-            id={`oc-datagrid-controls-cancel-${this.props.id}`}
+            tabIndex={tabIndex + 2}
+            id={`oc-datagrid-controls-cancel-${id}`}
           >
             <M id="Cancel" />
           </Button>
-          { this.props.isCreating &&
+          {isCreating &&
             <Button
-              disabled={this.props.isBusy || this.props.disableActions}
+              disabled={isBusy || disableActions}
               onClick={this.handleAddButtonClick}
-              tabIndex={this.props.tabIndex + 3}
-              id={`oc-datagrid-controls-add-${this.props.id}`}
+              tabIndex={tabIndex + 3}
+              id={`oc-datagrid-controls-add-${id}`}
             >
               <M id="Add" />
             </Button>
@@ -123,21 +136,21 @@ export default class InlineEditControls extends React.PureComponent {
     return (
       <div className="oc-datagrid-inline-edit-controls">
         <CellToolTip
-          id={`oc-datagrid-controls-tooltip-${this.props.id}`}
-          messageId={this.props.disableActions ? this.props.disableActionsMessage : undefined}
+          id={`oc-datagrid-controls-tooltip-${id}`}
+          messageId={disableActions ? disableActionsMessage : undefined}
         >
           <Button
-            disabled={this.props.isBusy}
+            disabled={isBusy}
             onClick={this.handleEditButtonClick}
-            id={`oc-datagrid-controls-edit-${this.props.id}`}
+            id={`oc-datagrid-controls-edit-${id}`}
           >
             <M id="Edit" />
           </Button>
-          { this.props.inlineAdd &&
+          {inlineAdd &&
             <Button
-              disabled={this.props.isBusy}
+              disabled={isBusy}
               onClick={this.handleCreateButtonClick}
-              id={`oc-datagrid-controls-create-${this.props.id}`}
+              id={`oc-datagrid-controls-create-${id}`}
             >
               <M id="Add" />
             </Button>


### PR DESCRIPTION
Add `disableActionSave` prop
Combine error and warning status for cells with 'error' type prioritized
Add grey corner to edited cells