### PR TITLE
Items structure change, checkedItems type change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## <next>
+* Change items' structure and checkedItems type of `DropdownMultiSelect` and `MultiSelectItem` components to make them compatible with `react-select` structure
 
 ## 4.2.3
 * Change `string` type to one of `element` and `string` type to `Wizard`'s `localizationTexts` and step `name` props

--- a/examples/components/dropdown-multi-select-view/dropdown-multi-select-view.component.jsx
+++ b/examples/components/dropdown-multi-select-view/dropdown-multi-select-view.component.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Map } from 'immutable';
+import { List } from 'immutable';
 
 import { DropdownMultiSelect } from '../../../src/index';
 
@@ -7,7 +7,7 @@ export default class DropdownMultiSelectView extends React.PureComponent {
 
   constructor(props) {
     super(props);
-    this.state = { checkedItems: Map() };
+    this.state = { checkedItems: List() };
   }
 
   componentWillMount() {
@@ -21,7 +21,7 @@ export default class DropdownMultiSelectView extends React.PureComponent {
   initializeItems = () => {
     const items = [];
     for (let i = 0; i < 300; i += 1) {
-      items.push({ id: i, text: `Item ${i}` });
+      items.push({ value: i, label: `Item ${i}` });
     }
     return items;
   };

--- a/examples/components/multi-select-view/multi-select-view.component.jsx
+++ b/examples/components/multi-select-view/multi-select-view.component.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Map } from 'immutable';
+import { List } from 'immutable';
 
 import { MultiSelect } from '../../../src/multi-select/index';
 import './multi-select-view.component.scss';
@@ -8,7 +8,7 @@ export default class MultiSelectView extends React.PureComponent {
 
   constructor(props) {
     super(props);
-    this.state = { checkedItems: Map() };
+    this.state = { checkedItems: List() };
   }
 
   componentWillMount() {
@@ -22,16 +22,16 @@ export default class MultiSelectView extends React.PureComponent {
   initializeItems = () => (
     [
       {
-        id: 1,
-        text: 'Item 1',
+        value: 1,
+        label: 'Item 1',
       },
       {
-        id: 2,
-        text: 'Item 2',
+        value: 2,
+        label: 'Item 2',
       },
       {
-        id: 3,
-        text: 'EUR FI00 3333 3333 1111 11 Account ABCDEF',
+        value: 3,
+        label: 'EUR FI00 3333 3333 1111 11 Account ABCDEF',
       },
     ]);
 

--- a/src/dropdown-multi-select/README.md
+++ b/src/dropdown-multi-select/README.md
@@ -16,32 +16,32 @@ It contains **DropdownMultiSelect** react component that allows one to select mu
 
 Prop name | Type | Default | Description
 --- | --- | --- | ---
-id | string | required | ID of the component
-items | array | required | Array of items to display in the dropdown
-checkedItems | Immutable.Map | | Identifiers of checked items
+checkedItems | Immutable.List | | Values of checked items
 defaultPlacehoder | string | '{N} items selected' | Placeholder to be displayed for 0 or more than 1 checked items
+id | [number, string] | required | ID of the component
+items | array | required | Array of items to display in the dropdown
 onChange | function | | Callback that is called when an item is clicked
 
 #### DropdownMultiSelect - items props
 
 Name | Type | Default | Description
 --- | --- | --- | ---
-id | [number, string] | | Item identifier
-text | string | | Item label
-textPlaceholder | string | | Item label to be displayed as a placeholder when checked
+label | string | required | Item label
+labelPlaceholder | string | | Item label to be displayed as a placeholder when checked
+value | [bool, number, string] | required | Item value
 
 ### Code example
 
 ```jsx
 import React from 'react';
-import { Map } from 'immutable';
+import { List } from 'immutable';
 import { DropdownMultiSelect } from '@opuscapita/oc-common-ui';
 
 export default class DropdownMultiSelectView extends React.Component {
   
   constructor(props) {
     super(props);
-    this.state = { checkedItems: Map() };
+    this.state = { checkedItems: List() };
   }
 
   onChange = (checkedItems) => {
@@ -51,7 +51,7 @@ export default class DropdownMultiSelectView extends React.Component {
   render() {
     const items = [];
     for (let i = 0; i < 10; i += 1) {
-      items.push({ id: i, text: `Item ${i}` });
+      items.push({ value: i, label: `Item ${i}` });
     }
     return (
       <DropdownMultiSelect

--- a/src/dropdown-multi-select/dropdown-multi-select.component.jsx
+++ b/src/dropdown-multi-select/dropdown-multi-select.component.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
-import { Map } from 'immutable';
+import { List } from 'immutable';
 import { FormControl, InputGroup } from 'react-bootstrap';
 
 import { DropdownContainer } from '../dropdown-container/index';
@@ -12,22 +12,28 @@ import './dropdown-multi-select.component.scss';
 export default class DropdownMultiSelect extends React.PureComponent {
 
   static propTypes = {
-    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
-    items: PropTypes.arrayOf(PropTypes.shape({
-      id: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.number,
-      ]).isRequired,
-      text: PropTypes.string.isRequired,
-      textPlaceholder: PropTypes.string,
-    })).isRequired,
-    checkedItems: ImmutablePropTypes.map,
+    checkedItems: ImmutablePropTypes.list,
     defaultPlaceholder: PropTypes.string,
+    id: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
+    ]).isRequired,
+    items: PropTypes.arrayOf(
+      PropTypes.shape({
+        label: PropTypes.string.isRequired,
+        labelPlaceholder: PropTypes.string,
+        value: PropTypes.oneOfType([
+          PropTypes.bool,
+          PropTypes.number,
+          PropTypes.string,
+        ]).isRequired,
+      }),
+    ).isRequired,
     onChange: PropTypes.func,
   };
 
   static defaultProps = {
-    checkedItems: Map(),
+    checkedItems: List(),
     defaultPlaceholder: '{N} items selected',
     onChange: () => {},
   };
@@ -43,11 +49,10 @@ export default class DropdownMultiSelect extends React.PureComponent {
       return defaultPlaceholder.replace('{N}', checkedItems.size);
     }
     if (checkedItems.size === 1) {
-      const [...keys] = checkedItems.keys();
-      const index = items.findIndex(i => i.id === keys[0]);
+      const index = items.findIndex(i => i.value === checkedItems.get(0));
       if (index > -1) {
-        return items[index].textPlaceholder !== undefined ?
-          items[index].textPlaceholder : items[index].text;
+        return items[index].labelPlaceholder !== undefined ?
+          items[index].labelPlaceholder : items[index].label;
       }
     }
     return defaultPlaceholder.replace('{N}', '1');
@@ -64,13 +69,13 @@ export default class DropdownMultiSelect extends React.PureComponent {
 
   filterItems = (items) => {
     const filterValue = this.state.filterValue.replace(/\s/g, '').toLowerCase();
-    return items.filter(i => i.text.replace(/\s/g, '').toLowerCase().match(filterValue) !== null);
+    return items.filter(i => i.label.replace(/\s/g, '').toLowerCase().match(filterValue) !== null);
   }
 
   handleClear = () => {
     this.preventToggle = true;
     if (this.props.checkedItems.size > 0) {
-      this.props.onChange(Map());
+      this.props.onChange(List());
     }
   }
 

--- a/src/multi-select/README.md
+++ b/src/multi-select/README.md
@@ -16,29 +16,29 @@ It contains **MultiSelect** react component that displays a list of items with c
 
 Prop name | Type | Default | Description
 --- | --- | --- | ---
+checkedItems | Immutable.list | | Values of checked items
 items | array | required | Array of items
-checkedItems | Immutable.Map | | Identifiers of checked items
 onChange | function | | Callback that is called when an item is clicked
 
 #### MultiSelect - items props
 
 Name | Type | Default | Description
 --- | --- | --- | ---
-id | [number, string] | | Item identifier
-text | string | | Item label
+label | string | required | Item label
+value | [bool, number, string] | required | Item value
 
 ### Code example
 
 ```jsx
 import React from 'react';
-import { Map } from 'immutable';
+import { List } from 'immutable';
 import { MultiSelect } from '@opuscapita/oc-common-ui';
 
 export default class MultiSelectView extends React.Component {
   
   constructor(props) {
     super(props);
-    this.state = { checkedItems: Map() };
+    this.state = { checkedItems: List() };
   }
 
   onChange = (checkedItems) => {
@@ -48,7 +48,7 @@ export default class MultiSelectView extends React.Component {
   render() {
     const items = [];
     for (let i = 0; i < 10; i += 1) {
-      items.push({ id: i, text: `Item ${i}` });
+      items.push({ value: i, label: `Item ${i}` });
     }
     return (
       <MultiSelect

--- a/src/multi-select/multi-select-item/multi-select-item.component.jsx
+++ b/src/multi-select/multi-select-item/multi-select-item.component.jsx
@@ -8,11 +8,12 @@ export default class MultiSelectItem extends React.PureComponent {
 
   static propTypes = {
     item: PropTypes.shape({
-      id: PropTypes.oneOfType([
-        PropTypes.string,
+      label: PropTypes.string.isRequired,
+      value: PropTypes.oneOfType([
+        PropTypes.bool,
         PropTypes.number,
+        PropTypes.string,
       ]).isRequired,
-      text: PropTypes.string.isRequired,
     }).isRequired,
     isChecked: PropTypes.bool.isRequired,
     onChange: PropTypes.func,
@@ -23,7 +24,7 @@ export default class MultiSelectItem extends React.PureComponent {
   };
 
   render() {
-    const { id, text } = this.props.item;
+    const { label, value } = this.props.item;
     const isChecked = this.props.isChecked;
     const onChange = this.props.onChange;
     return (
@@ -31,11 +32,11 @@ export default class MultiSelectItem extends React.PureComponent {
         <Checkbox
           className="oc-multi-select-item-checkbox"
           checked={isChecked}
-          id={id}
-          onChange={() => onChange(id, !isChecked)}
+          id={value}
+          onChange={() => onChange(value, !isChecked)}
         >
-          <span className="oc-multi-select-item-text">
-            {text}
+          <span className="oc-multi-select-item-label">
+            {label}
           </span>
         </Checkbox>
       </div>

--- a/src/multi-select/multi-select.component.jsx
+++ b/src/multi-select/multi-select.component.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Map } from 'immutable';
+import { List } from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
 import MultiSelectItem from './multi-select-item/multi-select-item.component';
@@ -9,42 +9,46 @@ import './multi-select.component.scss';
 export default class MultiSelect extends React.PureComponent {
 
   static propTypes = {
-    items: PropTypes.arrayOf(PropTypes.shape({
-      id: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.number,
-      ]).isRequired,
-      text: PropTypes.string.isRequired,
-    })).isRequired,
-    checkedItems: ImmutablePropTypes.map,
+    items: PropTypes.arrayOf(
+      PropTypes.shape({
+        label: PropTypes.string.isRequired,
+        value: PropTypes.oneOfType([
+          PropTypes.bool,
+          PropTypes.number,
+          PropTypes.string,
+        ]).isRequired,
+      }),
+    ).isRequired,
+    checkedItems: ImmutablePropTypes.list,
     onChange: PropTypes.func,
   };
 
   static defaultProps = {
-    checkedItems: Map(),
+    checkedItems: List(),
     onChange: () => {},
   };
 
-  handleChange = (id, isChecked) => {
+  handleChange = (value, isChecked) => {
     const { checkedItems, onChange } = this.props;
-    if (isChecked) {
-      onChange(checkedItems.set(id, isChecked));
-    } else {
-      onChange(checkedItems.delete(id));
+    const valueIndex = checkedItems.indexOf(value);
+    if (isChecked && valueIndex === -1) {
+      onChange(checkedItems.push(value));
+    } else if (!isChecked && valueIndex > -1) {
+      onChange(checkedItems.deleteIn([valueIndex]));
     }
   }
 
-  isChecked = (id, checkedItems) => checkedItems.get(id) === true;
+  isChecked = (value, checkedItems) => checkedItems.indexOf(value) > -1;
 
   render() {
     const { items, checkedItems } = this.props;
     return (
       <div className="oc-multi-select">
         {items.map((item) => {
-          const isChecked = this.isChecked(item.id, checkedItems);
+          const isChecked = this.isChecked(item.value, checkedItems);
           return (
             <MultiSelectItem
-              key={item.id}
+              key={item.value}
               isChecked={isChecked}
               item={item}
               onChange={this.handleChange}

--- a/test/dropdown-multi-select/dropdown-multi-select.component.spec.js
+++ b/test/dropdown-multi-select/dropdown-multi-select.component.spec.js
@@ -16,12 +16,12 @@ describe('DropdownMultiSelect component', function describe() {
       id: 'dropdownMultiSelectExample',
       items: [
         {
-          id: 1,
-          text: 'Item 1',
+          value: 1,
+          label: 'Item 1',
         },
         {
-          id: 2,
-          text: 'Item 2',
+          value: 2,
+          label: 'Item 2',
         },
       ],
       onChange: sinon.spy(),
@@ -32,7 +32,7 @@ describe('DropdownMultiSelect component', function describe() {
     );
 
     expect(wrapper.find('.oc-multi-select-item-checkbox').length).to.eql(2);
-    expect(wrapper.find('.oc-multi-select-item-text').at(0).text()).to.eql('Item 1');
+    expect(wrapper.find('.oc-multi-select-item-label').at(0).text()).to.eql('Item 1');
 
     wrapper.find('#2').simulate('change');
     expect(props.onChange.called).to.be.true;

--- a/test/multi-select/multi-select-item/multi-select-item.component.spec.js
+++ b/test/multi-select/multi-select-item/multi-select-item.component.spec.js
@@ -13,8 +13,8 @@ describe('MultiSelectItem component', function describe() {
   it('should render correctly', function it() {
     const props = {
       item: {
-        id: 1,
-        text: 'Item 1',
+        value: 1,
+        label: 'Item 1',
       },
       isChecked: true,
     };
@@ -23,7 +23,7 @@ describe('MultiSelectItem component', function describe() {
       <MultiSelectItem {...props} />,
     );
 
-    expect(wrapper.find('.oc-multi-select-item-text').at(0).text()).to.eql('Item 1');
+    expect(wrapper.find('.oc-multi-select-item-label').at(0).text()).to.eql('Item 1');
     expect(wrapper.find('#1').props().checked).to.be.true;
   });
 });

--- a/test/multi-select/multi-select.component.spec.js
+++ b/test/multi-select/multi-select.component.spec.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
-import { Map } from 'immutable';
+import { List } from 'immutable';
 
 import { MultiSelect } from '../../src/multi-select/index';
 
@@ -12,15 +12,15 @@ import { MultiSelect } from '../../src/multi-select/index';
 describe('MultiSelect component', function describe() {
   it('should render correctly', function it() {
     const props = {
-      checkedItems: Map(),
+      checkedItems: List(),
       items: [
         {
-          id: 1,
-          text: 'Item 1',
+          value: 1,
+          label: 'Item 1',
         },
         {
-          id: 2,
-          text: 'Item 2',
+          value: 2,
+          label: 'Item 2',
         },
       ],
     };
@@ -30,6 +30,6 @@ describe('MultiSelect component', function describe() {
     );
 
     expect(wrapper.find('.oc-multi-select-item-checkbox').length).to.eql(2);
-    expect(wrapper.find('.oc-multi-select-item-text').at(0).text()).to.eql('Item 1');
+    expect(wrapper.find('.oc-multi-select-item-label').at(0).text()).to.eql('Item 1');
   });
 });


### PR DESCRIPTION
There are cases when the same data can be used in react-select or dropdown-multi-select component. The same type and object structure of 'items' and 'checkedItems' props eliminates the need to loop through the data to format it for the needs of the specific component