### PR TITLE
Wizard improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## <next>
+* Added props `disableSave` and `disableCancel` to disable wizard buttons.
+* Default button titles in `Wizard` set to Save and Close
+* Only the active step is highlighted in the navbar of `Wizard` component.
 
 ## 4.2.5
-* Add `hasRequiredProps` and `hasRequiredPropsErrors` and wrap `name` as a lable in `Wizard`
+* Add `hasRequiredProps` and `hasRequiredPropsErrors` and wrap `name` as a label in `Wizard`
 * Change hover and selected colors of select options
 * Add `item.id` as required prop to `ResponsiveNavbar`
 

--- a/examples/components/wizard-view/wizard-view.component.jsx
+++ b/examples/components/wizard-view/wizard-view.component.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from 'react-bootstrap';
+import { Button, Checkbox } from 'react-bootstrap';
 
 import { Wizard } from '../../../src/index';
 
@@ -20,6 +20,8 @@ export default class WizardView extends React.Component {
     super();
     this.state = {
       showWizard: false,
+      disableSave: false,
+      disableClose: false,
     };
 
     this.steps = [
@@ -53,7 +55,7 @@ export default class WizardView extends React.Component {
   getContent = (text) => {
     const content = (
       <div style={contentStyle}>
-        { text }
+        {text}
       </div>
     );
 
@@ -79,6 +81,18 @@ export default class WizardView extends React.Component {
     });
   }
 
+  toggleDisableSave = () => {
+    this.setState({
+      disableSave: !this.state.disableSave,
+    });
+  }
+
+  toggleDisableClose = () => {
+    this.setState({
+      disableClose: !this.state.disableClose,
+    });
+  }
+
   render() {
     return (
       <div className="oc-content" style={{ height: '100%' }}>
@@ -87,13 +101,30 @@ export default class WizardView extends React.Component {
             <Wizard
               save={this.saveWizard}
               cancel={this.cancelWizard}
+              disableSave={this.state.disableSave}
+              disableCancel={this.state.disableClose}
               steps={this.steps}
-              localizationTexts={{ save: 'Save', cancel: 'Cancel' }}
+              localizationTexts={{ save: 'Save', cancel: 'Close' }}
               showPageIndicator={false}
             />
-          : <Button onClick={this.showWizard}>
-              Start wizard...
-            </Button>}
+          :
+            <div>
+              <Button onClick={this.showWizard}>
+                Start wizard...
+                </Button>
+              <Checkbox
+                checked={this.state.disableSave}
+                onChange={this.toggleDisableSave}
+              >
+                Disable save button
+                </Checkbox>
+              <Checkbox
+                checked={this.state.disableClose}
+                onChange={this.toggleDisableClose}
+              >
+                Disable close button
+                </Checkbox>
+            </div>}
       </div>
     );
   }

--- a/src/wizard/README.md
+++ b/src/wizard/README.md
@@ -19,8 +19,10 @@ N/A
 Name | Type | Default | Description
 --- | --- | --- | ---
 cancel | function | required | Callback function called, when the wizard is cancelled
-localizationTexts | map | required| Localization texts for save and close buttons
+disableCancel | bool | false | Disable the Cancel button
+localizationTexts | map | { save: 'Save', cancel: 'Cancel' } | Localization texts for save and close buttons. Defaults to 'Save' and 'Close'
 save | function | required | Callback function called, when the wizard is saved
+disableSave | bool | false | Disable the Save button
 showPageIndicator | bool | true | Sign of page indicator showing
 steps | array | required | Steps of the wizard
 
@@ -51,7 +53,7 @@ class WizardView extends React.Component {
       component: <div>My wizard page 2</div>,
     }];
   }
-  
+
   render() {
     return (
       <Wizard

--- a/src/wizard/wizard-footer.component.jsx
+++ b/src/wizard/wizard-footer.component.jsx
@@ -11,7 +11,9 @@ export default class WizardFooter extends React.PureComponent {
 
   static propTypes = {
     save: PropTypes.func.isRequired,
+    disableSave: PropTypes.bool,
     cancel: PropTypes.func.isRequired,
+    disableCancel: PropTypes.bool,
     localizationTexts: PropTypes.shape({
       save: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
       cancel: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
@@ -27,6 +29,8 @@ export default class WizardFooter extends React.PureComponent {
 
   static defaultProps = {
     showPageIndicator: true,
+    disableSave: false,
+    disableCancel: false,
   }
 
   getIndicators = () => (
@@ -59,6 +63,7 @@ export default class WizardFooter extends React.PureComponent {
           <Button
             id="save-button"
             onClick={this.props.save}
+            disabled={this.props.disableSave}
           >
             {localizationTexts.save}
           </Button>
@@ -66,6 +71,7 @@ export default class WizardFooter extends React.PureComponent {
           <Button
             id="cancel-button"
             onClick={this.props.cancel}
+            disabled={this.props.disableCancel}
           >
             {localizationTexts.cancel}
           </Button>

--- a/src/wizard/wizard-header.component.jsx
+++ b/src/wizard/wizard-header.component.jsx
@@ -99,7 +99,7 @@ export default class WizardHeader extends React.PureComponent {
             return (
               <li
                 key={step.id}
-                className={i <= this.props.currentStep ? 'doing' : ''}
+                className={i === this.props.currentStep ? 'doing' : ''}
                 ref={(node) => { this.tabElements[i] = node; }}
               >
                 <a

--- a/src/wizard/wizard.component.jsx
+++ b/src/wizard/wizard.component.jsx
@@ -47,6 +47,8 @@ export default class Wizard extends React.PureComponent {
           selectPage={this.selectPage}
           save={this.props.save}
           cancel={this.props.cancel}
+          disableSave={this.props.disableSave}
+          disableCancel={this.props.disableCancel}
           localizationTexts={this.props.localizationTexts}
           showPageIndicator={this.props.showPageIndicator}
         />
@@ -58,11 +60,19 @@ export default class Wizard extends React.PureComponent {
 Wizard.defaultProps = {
   activeStep: 0,
   showPageIndicator: true,
+  localizationTexts: {
+    save: 'Save',
+    cancel: 'Close',
+  },
+  disableSave: false,
+  disableCancel: false,
 };
 
 Wizard.propTypes = {
   save: PropTypes.func.isRequired,
+  disableSave: PropTypes.bool,
   cancel: PropTypes.func.isRequired,
+  disableCancel: PropTypes.bool,
   steps: PropTypes.arrayOf(PropTypes.shape({
     component: PropTypes.node.isRequired,
     hasRequiredProps: PropTypes.bool,

--- a/src/wizard/wizard.component.jsx
+++ b/src/wizard/wizard.component.jsx
@@ -83,7 +83,7 @@ Wizard.propTypes = {
   localizationTexts: PropTypes.shape({
     save: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     cancel: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-  }).isRequired,
+  }),
   activeStep: PropTypes.number,
   showPageIndicator: PropTypes.bool,
 };


### PR DESCRIPTION
* Added props `disableSave` and `disableCancel` to disable wizard buttons.
* Default button titles in `Wizard` set to Save and Close
* Only the active step is highlighted in the navbar of `Wizard` component.
