### PR TITLE
Responsive navbar modifications (feature/86050)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## <next>
 * Fix Tab and arrow keys navigation for disabled columns of `Datagrid`
+* responsive navbar modifications and new features
 
 ## 4.4.1
 * Fix Tab issue in editing mode of `Datagrid`

--- a/examples/components/responsive-navbar-view/responsive-navbar-view.component.jsx
+++ b/examples/components/responsive-navbar-view/responsive-navbar-view.component.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { withRouter, routerShape } from 'react-router';
 import { ResponsiveNavbar } from '../../../src/index';
-
+import './responsive-navbar-view.scss';
 
 const ResponsiveNavbarView = (props) => {
   const list = [
@@ -14,7 +14,7 @@ const ResponsiveNavbarView = (props) => {
   const activeKey = 2;
 
   return (
-    <div style={{ marginTop: '10px' }}>
+    <div className="navbar-top-margin">
       <ResponsiveNavbar
         activeKey={activeKey}
         list={list}

--- a/examples/components/responsive-navbar-view/responsive-navbar-view.component.jsx
+++ b/examples/components/responsive-navbar-view/responsive-navbar-view.component.jsx
@@ -18,6 +18,7 @@ const ResponsiveNavbarView = (props) => {
       <ResponsiveNavbar
         activeKey={activeKey}
         list={list}
+        showNavItemBorder
         onSelect={(href) => { props.router.push(href); }}
       />
     </div>

--- a/examples/components/responsive-navbar-view/responsive-navbar-view.component.jsx
+++ b/examples/components/responsive-navbar-view/responsive-navbar-view.component.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { withRouter, routerShape } from 'react-router';
-
 import { ResponsiveNavbar } from '../../../src/index';
 
 
@@ -15,11 +14,13 @@ const ResponsiveNavbarView = (props) => {
   const activeKey = 2;
 
   return (
-    <ResponsiveNavbar
-      activeKey={activeKey}
-      list={list}
-      onSelect={(href) => { props.router.push(href); }}
-    />
+    <div style={{ marginTop: '10px' }}>
+      <ResponsiveNavbar
+        activeKey={activeKey}
+        list={list}
+        onSelect={(href) => { props.router.push(href); }}
+      />
+    </div>
   );
 };
 

--- a/examples/components/responsive-navbar-view/responsive-navbar-view.scss
+++ b/examples/components/responsive-navbar-view/responsive-navbar-view.scss
@@ -1,0 +1,3 @@
+.navbar-top-margin {
+  margin-top: 10px;
+}

--- a/src/responsive-navbar/README.md
+++ b/src/responsive-navbar/README.md
@@ -23,9 +23,11 @@ N/A
 | activeKey         | number                                  | required  | Navbar item to be active initially    |
 | list              | list [{id: id, name: name, href: href}] | required  |                                       |
 | showNavItemBorder | boolean                                 | false     | show bottom-border below navbar items |
+| showNavItemTooltip| boolean                                 | true      | enables tooltips for nav items        |
+| tooltipDelay      | number                                  | 2000      | delay before tooltip becomes visible  |
 | fontSize          | string                                  | 'inherit' | override for  fontSize                |
 | fontWeight        | string                                  | 'inherit' | override for fontWeight               |
-| placeholder       | string                                  | 'more...' | ovverided for placeholder text        |
+| placeholder       | string                                  | 'more...' | override for placeholder text        |
 
 | Function | Parameters   | Returns | Description                              |
 | -------- | ------------ | ------- | ---------------------------------------- |

--- a/src/responsive-navbar/README.md
+++ b/src/responsive-navbar/README.md
@@ -22,10 +22,10 @@ N/A
 | ------------------| --------------------------------------- | --------- | ------------------------------------- |
 | activeKey         | number                                  | required  | Navbar item to be active initially    |
 | list              | list [{id: id, name: name, href: href}] | required  |                                       |
-| showNavItemBorder | boolean                                 | false      | show bottom-border below navbar items |
+| showNavItemBorder | boolean                                 | false     | show bottom-border below navbar items |
 | fontSize          | string                                  | 'inherit' | override for  fontSize                |
-| fontWeight        | string                                  | 'inherit' | override ofr fontWeight               |
-
+| fontWeight        | string                                  | 'inherit' | override for fontWeight               |
+| placeholder       | string                                  | 'more...' | ovverided for placeholder text        |
 
 | Function | Parameters   | Returns | Description                              |
 | -------- | ------------ | ------- | ---------------------------------------- |

--- a/src/responsive-navbar/README.md
+++ b/src/responsive-navbar/README.md
@@ -4,7 +4,7 @@ Back to [oc-common-ui](../../README.md)
 
 ### Description
 
-Navbar component that changes to dropdown if content doesn't fit horizontally to the navbar content area.
+Navbar component that moves the navbar items to a dropdown, if they do not fit in the content area.
 
 ### Dependencies
 
@@ -18,10 +18,14 @@ N/A
 
 #### ResponsiveNavbar
 
-| Prop name | Type                                    | Default  | Description                        |
-| --------- | --------------------------------------- | -------- | ---------------------------------- |
-| activeKey | number                                  | required | Navbar item to be active initially |
-| list      | list [{id: id, name: name, href: href}] | required |                                    |
+| Prop name         | Type                                    | Default   | Description                           |
+| ------------------| --------------------------------------- | --------- | ------------------------------------- |
+| activeKey         | number                                  | required  | Navbar item to be active initially    |
+| list              | list [{id: id, name: name, href: href}] | required  |                                       |
+| showNavItemBorder | boolean                                 | false      | show bottom-border below navbar items |
+| fontSize          | string                                  | 'inherit' | override for  fontSize                |
+| fontWeight        | string                                  | 'inherit' | override ofr fontWeight               |
+
 
 | Function | Parameters   | Returns | Description                              |
 | -------- | ------------ | ------- | ---------------------------------------- |
@@ -52,4 +56,3 @@ const ResponsiveNavbarView = (props) => {
 
 export default withRouter(ResponsiveNavbarView);
 ```
-

--- a/src/responsive-navbar/responsive-navbar.component.jsx
+++ b/src/responsive-navbar/responsive-navbar.component.jsx
@@ -78,9 +78,9 @@ export class ResponsiveNavbar extends React.Component {
       <button
         className={index === this.props.activeKey &&
           index <= this.state.lastVisibleItemIndex ?
-          `${className} selected-border` : className}
+          `${className} selected-border` : `${className}`}
         style={{ fontWeight: this.props.fontWeight, fontSize: this.props.fontSize }}
-        id={item.id}
+        id={`navitemref${String(index)}`}
         key={index}
         ref={`navitemref${String(index)}`}
         onClick={() => { this.props.onSelect(item.href); }}
@@ -118,13 +118,15 @@ export class ResponsiveNavbar extends React.Component {
         ref: `navitemref${String(index)}`,
       }),
     );
-    const className = this.props.activeKey >= this.state.lastVisibleItemIndex ?
-    'selected-border' : '';
+
+    const inactiveBorder = this.props.showNavItemBorder ? 'inactive-border' : '';
+    const borderClass = this.props.activeKey >= this.state.lastVisibleItemIndex ?
+    'selected-border' : inactiveBorder;
 
     return (
       <div
         id="responsive-navbar-select"
-        className={className}
+        className={borderClass}
         style={{ fontWeight: this.props.fontWeight, fontSize: this.props.fontSize }}
       >
         <Select
@@ -160,7 +162,6 @@ ResponsiveNavbar.propTypes = {
   fontWeight: PropTypes.string,
   activeKey: PropTypes.number.isRequired,
   list: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.string.isRequired,
     name: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.node,

--- a/src/responsive-navbar/responsive-navbar.component.jsx
+++ b/src/responsive-navbar/responsive-navbar.component.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import Select from 'react-select';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import 'react-select/dist/react-select.css';
 import './responsive-navbar.scss';
 
@@ -68,6 +69,28 @@ export class ResponsiveNavbar extends React.Component {
     this.props.router.push(item.value);
   }
 
+  tooltipWrapper = (node, index, tooltipContent) => {
+    const tooltip = <Tooltip id="tooltip">{tooltipContent}</Tooltip>;
+    return !this.props.showNavItemTooltip ? node :
+    <OverlayTrigger placement="bottom" key={index} overlay={tooltip} delayShow={this.props.tooltipDelay}>
+      {node}
+    </OverlayTrigger>;
+  }
+
+  navbarItem = (item, index, className) => (
+    <button
+      className={index === this.props.activeKey &&
+        index <= this.state.lastVisibleItemIndex ?
+        `${className} selected-border` : `${className}`}
+      style={{ fontWeight: this.props.fontWeight, fontSize: this.props.fontSize }}
+      id={`navitemref${String(index)}`}
+      ref={`navitemref${String(index)}`}
+      onClick={() => { this.props.onSelect(item.href); }}
+    >
+      <span className="responsive-navbar-item-text">{item.name}</span>
+    </button>
+  )
+
   navbar = () => {
     const list = this.state.lastVisibleItemIndex >= 0 ?
       this.props.list.slice(0, this.state.lastVisibleItemIndex)
@@ -75,18 +98,7 @@ export class ResponsiveNavbar extends React.Component {
     const className = this.props.showNavItemBorder ?
       'responsive-navbar-item inactive-border' : 'responsive-navbar-item';
     const items = list.map((item, index) => (
-      <button
-        className={index === this.props.activeKey &&
-          index <= this.state.lastVisibleItemIndex ?
-          `${className} selected-border` : `${className}`}
-        style={{ fontWeight: this.props.fontWeight, fontSize: this.props.fontSize }}
-        id={`navitemref${String(index)}`}
-        key={index}
-        ref={`navitemref${String(index)}`}
-        onClick={() => { this.props.onSelect(item.href); }}
-      >
-        <span className="responsive-navbar-item-text">{item.name}</span>
-      </button>
+      this.tooltipWrapper(this.navbarItem(item, index, className), index, item.name)
     ));
 
     return (
@@ -151,6 +163,8 @@ export class ResponsiveNavbar extends React.Component {
 ResponsiveNavbar.defaultProps = {
   onSelect: null,
   showNavItemBorder: false,
+  showNavItemTooltip: true,
+  tooltipDelay: 2000,
   fontSize: 'inherit',
   fontWeight: 'inherit',
   placeholder: 'more...',
@@ -158,6 +172,8 @@ ResponsiveNavbar.defaultProps = {
 
 ResponsiveNavbar.propTypes = {
   showNavItemBorder: PropTypes.bool,
+  showNavItemTooltip: PropTypes.bool,
+  tooltipDelay: PropTypes.number,
   fontSize: PropTypes.string,
   fontWeight: PropTypes.string,
   placeholder: PropTypes.string,

--- a/src/responsive-navbar/responsive-navbar.component.jsx
+++ b/src/responsive-navbar/responsive-navbar.component.jsx
@@ -134,7 +134,7 @@ export class ResponsiveNavbar extends React.Component {
           multi={false}
           value={this.props.list[this.props.activeKey].href}
           clearable={false}
-          placeholder={'more...'}
+          placeholder={this.props.placeholder}
           options={items}
           onChange={(item) => { this.props.onSelect(item.value); }}
           inputProps={{ id: 'ocResponsiveNavbarSelect' }}
@@ -153,12 +153,14 @@ ResponsiveNavbar.defaultProps = {
   showNavItemBorder: false,
   fontSize: 'inherit',
   fontWeight: 'inherit',
+  placeholder: 'more...',
 };
 
 ResponsiveNavbar.propTypes = {
   showNavItemBorder: PropTypes.bool,
   fontSize: PropTypes.string,
   fontWeight: PropTypes.string,
+  placeholder: PropTypes.string,
   activeKey: PropTypes.number.isRequired,
   list: PropTypes.arrayOf(PropTypes.shape({
     name: PropTypes.oneOfType([

--- a/src/responsive-navbar/responsive-navbar.component.jsx
+++ b/src/responsive-navbar/responsive-navbar.component.jsx
@@ -7,101 +7,132 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import Select from 'react-select';
-import { Navbar,
-         Nav,
-         NavItem } from 'react-bootstrap';
-
 import 'react-select/dist/react-select.css';
 import './responsive-navbar.scss';
-
 
 export class ResponsiveNavbar extends React.Component {
 
   constructor(props) {
     super(props);
     this.state = {
-      wrapping: false,
+      updateDimenssions: true,
+      lastVisibleItemIndex: -1,
       lastWidth: 0,
     };
   }
 
   componentDidMount() {
-    window.addEventListener('resize', this.updateDimensions);
+    window.addEventListener('resize', this.handleResizeEvent);
+    window.addEventListener('orientationchange', this.handleResizeEvent); // for mobile support
     // Component is not rendered yet by browser when DidMount is called
     setTimeout(() => {
-      this.updateDimensions();
+      this.handleResizeEvent();
     }, 200);
   }
 
-  componentWillUnmount() {
-    window.removeEventListener('resize', this.updateDimensions);
-  }
-
-  updateDimensions = () => {
-    const firstRef = this.refs[`navitemref${String(0)}`];
-    const lastRef = this.refs[`navitemref${String(this.props.list.length - 1)}`];
-
-    const firstOffsetTop = ReactDOM.findDOMNode(firstRef)
-    ? ReactDOM.findDOMNode(firstRef).offsetTop
-    : 0;
-    const lastOffsetTop = ReactDOM.findDOMNode(lastRef)
-    ? ReactDOM.findDOMNode(lastRef).offsetTop
-    : 0;
-    // Re-render Navbar to see if it fits if screen width increases
-    // Do this once every 50 pixes.
-    const difference = window.innerWidth - this.state.lastWidth;
-    if (this.state.wrapping === true && difference > 10) {
-      this.setState({
-        wrapping: false,
-      });
-    } else if (firstOffsetTop !== lastOffsetTop) {
-      this.setState({
-        wrapping: true,
-        lastWidth: window.innerWidth,
+  componentDidUpdate() {
+    if (this.state.updateDimenssions) {
+      this.setState({ // eslint-disable-line react/no-did-update-set-state
+                      // 2nd render is triggered here in purpose
+        updateDimenssions: false,
+        lastVisibleItemIndex: this.indexOfLastVisibleNavItem(),
       });
     }
   }
 
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResizeEvent);
+    window.removeEventListener('orientationchange', this.handleResizeEvent); // for mobile support
+  }
+
+  indexOfLastVisibleNavItem = () => {
+    const NAV_ITEM_MIN_WIDTH = 200;
+    const container = this.refs.navbarContainer;
+    const containerWidth = ReactDOM.findDOMNode(container) ?
+      ReactDOM.findDOMNode(container).offsetWidth : 0;
+    const index = Math.trunc((containerWidth / NAV_ITEM_MIN_WIDTH));
+    return index >= 0 ? index : 0;
+  }
+
+  handleResizeEvent = () => {
+    const difference = window.innerWidth - this.state.lastWidth;
+    const UPDATE_THRESHOLD = 50;
+    if (Math.abs(difference) > UPDATE_THRESHOLD) {
+      this.setState({
+        updateDimenssions: true,
+        lastWidth: window.innerWidth,
+      });
+    }
+  }
   selectionChanged = (item) => {
     this.props.router.push(item.value);
   }
 
   navbar = () => {
-    const items = this.props.list.map((item, index) => (
-      <NavItem
+    const list = this.state.lastVisibleItemIndex >= 0 ?
+      this.props.list.slice(0, this.state.lastVisibleItemIndex)
+      : this.props.list;
+    const className = this.props.showNavItemBorder ?
+      'responsive-navbar-item inactive-border' : 'responsive-navbar-item';
+    const items = list.map((item, index) => (
+      <button
+        className={index === this.props.activeKey &&
+          index <= this.state.lastVisibleItemIndex ?
+          `${className} selected-border` : className}
+        style={{ fontWeight: this.props.fontWeight, fontSize: this.props.fontSize }}
         id={item.id}
         key={index}
-        eventKey={index}
         ref={`navitemref${String(index)}`}
         onClick={() => { this.props.onSelect(item.href); }}
       >
-        {item.name}
-      </NavItem>
+        <span className="responsive-navbar-item-text">{item.name}</span>
+      </button>
     ));
+
     return (
-      <Navbar fluid id="responsive-navbar">
-        <Nav
-          id="responsive-navbar"
-          bsStyle="pills"
-          activeKey={this.props.activeKey}
-        >
-          {items}
-        </Nav>
-      </Navbar>
+      <div
+        id="responsive-navbar-container"
+        ref={'navbarContainer'}
+      >
+        {items}
+        {this.combobox()}
+      </div>
     );
   }
 
   combobox = () => {
-    const items = this.props.list.map((item, index) =>
-      ({ value: item.href, label: item.name, id: index, ref: `navitemref${String(index)}` }),
+    if (this.state.lastVisibleItemIndex > this.props.list.length - 1) {
+      // return null if all nav items are visible
+      return null;
+    }
+
+    // slice nav items list and show invisible items in the combobox
+    const list = this.state.lastVisibleItemIndex >= 0 ?
+      this.props.list.slice(this.state.lastVisibleItemIndex)
+      : this.props.list;
+    const items = list.map((item, index) =>
+      ({
+        value: item.href,
+        label: item.name,
+        id: index,
+        ref: `navitemref${String(index)}`,
+      }),
     );
+    const className = this.props.activeKey >= this.state.lastVisibleItemIndex ?
+    'selected-border' : '';
+
     return (
-      <div id="responsive-navbar-select">
+      <div
+        id="responsive-navbar-select"
+        className={className}
+        style={{ fontWeight: this.props.fontWeight, fontSize: this.props.fontSize }}
+      >
         <Select
           name="responsiveNavbarSelect"
           multi={false}
-          clearable={false}
           value={this.props.list[this.props.activeKey].href}
+          clearable={false}
+          placeholder={'more...'}
           options={items}
           onChange={(item) => { this.props.onSelect(item.value); }}
           inputProps={{ id: 'ocResponsiveNavbarSelect' }}
@@ -111,16 +142,22 @@ export class ResponsiveNavbar extends React.Component {
   }
 
   render() {
-    return this.state.wrapping ? this.combobox() : this.navbar();
+    return this.navbar();
   }
-
 }
 
 ResponsiveNavbar.defaultProps = {
   onSelect: null,
+  showNavItemBorder: false,
+  navbarFontWeight: 'bold',
+  fontSize: 'inherit',
+  fontWeight: 'inherit',
 };
 
 ResponsiveNavbar.propTypes = {
+  showNavItemBorder: PropTypes.bool,
+  fontSize: PropTypes.string,
+  fontWeight: PropTypes.string,
   activeKey: PropTypes.number.isRequired,
   list: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.string.isRequired,

--- a/src/responsive-navbar/responsive-navbar.component.jsx
+++ b/src/responsive-navbar/responsive-navbar.component.jsx
@@ -50,7 +50,7 @@ export class ResponsiveNavbar extends React.Component {
     const container = this.refs.navbarContainer;
     const containerWidth = ReactDOM.findDOMNode(container) ?
       ReactDOM.findDOMNode(container).offsetWidth : 0;
-    const index = Math.trunc((containerWidth / NAV_ITEM_MIN_WIDTH));
+    const index = Math.floor((containerWidth / NAV_ITEM_MIN_WIDTH));
     return index >= 0 ? index : 0;
   }
 

--- a/src/responsive-navbar/responsive-navbar.component.jsx
+++ b/src/responsive-navbar/responsive-navbar.component.jsx
@@ -151,7 +151,6 @@ export class ResponsiveNavbar extends React.Component {
 ResponsiveNavbar.defaultProps = {
   onSelect: null,
   showNavItemBorder: false,
-  navbarFontWeight: 'bold',
   fontSize: 'inherit',
   fontWeight: 'inherit',
 };

--- a/src/responsive-navbar/responsive-navbar.scss
+++ b/src/responsive-navbar/responsive-navbar.scss
@@ -41,6 +41,7 @@ $select-max-width: $nav-item-width * 1.5;
       overflow-x: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
+      margin: 0 5px 0 5px;
   }
 }
 
@@ -52,6 +53,10 @@ $select-max-width: $nav-item-width * 1.5;
 
   .selected-border {
     border-bottom: 2px solid $oc-color-primary-orange;
+  }
+
+  .Select {
+    margin-left: 5px;
   }
 
   .Select-option {

--- a/src/responsive-navbar/responsive-navbar.scss
+++ b/src/responsive-navbar/responsive-navbar.scss
@@ -70,6 +70,6 @@ $select-max-width: $nav-item-width * 1.5;
   }
 
   .is-focused:not(.is-open) > .Select-control {
-    border-color: #d9d9d9 #ccc #b3b3b3 !important;
+    border-color: $oc-color-support-lightgray !important;
   }
 }

--- a/src/responsive-navbar/responsive-navbar.scss
+++ b/src/responsive-navbar/responsive-navbar.scss
@@ -1,12 +1,70 @@
+@import '../../styles/colors';
 
-#responsive-navbar-select {
-  margin-bottom: 0;
+$nav-item-width: 200px;
+$nav-bar-height: 44px;
+$select-min-width: $nav-item-width;
+$select-max-width: $nav-item-width * 1.5;
 
-  .Select-control {
-    min-width: 200px;
+#responsive-navbar-container {
+  display: flex;
+  flex-direction: row;
+  background-color: white;
+  min-width: $nav-item-width*2;
+  min-height: $nav-bar-height;
+  flex-grow: 1;
+
+  .responsive-navbar-item {
+    display: flex;
+    align-items:center;
+    max-width: $nav-item-width;
+    border:none;
+    height: $nav-bar-height;
+    background-color: transparent;
+    outline: none;
+
+    &:focus {
+      box-shadow: none;
+      ouline: none;
+    }
+  }
+
+  .inactive-border {
+    border-bottom: 2px solid $oc-color-support-lightgray;
+  }
+
+  .selected-border {
+    box-shadow: none;
+    border-bottom: 2px solid $oc-color-primary-orange;
+  }
+
+  .responsive-navbar-item-text {
+      overflow-x: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
   }
 }
 
-#responsive-navbar {
-  margin: 0;
+#responsive-navbar-select {
+  margin: 5px 0px 0px 0px;
+  font-size: inherit;
+  min-width: $select-min-width;
+  max-width: $select-max-width;
+
+  .selected-border {
+    border-bottom: 2px solid $oc-color-primary-orange;
+  }
+
+  .Select-option {
+    min-height: 32px;
+    color: inherit;
+  }
+
+  .Select-control, .Select-value, .Select-value-label {
+      color: inherit;
+      box-shadow: none;
+  }
+
+  .is-focused:not(.is-open) > .Select-control {
+    border-color: #d9d9d9 #ccc #b3b3b3 !important;
+  }
 }

--- a/test/responsive-navbar/responsive-navbar.component.spec.jsx
+++ b/test/responsive-navbar/responsive-navbar.component.spec.jsx
@@ -4,10 +4,8 @@
 import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
-import { NavItem } from 'react-bootstrap';
 import ReactDOM from 'react-dom';
 import sinon from 'sinon';
-
 import { ResponsiveNavbar } from
   '../../src/responsive-navbar/responsive-navbar.component';
 
@@ -33,25 +31,20 @@ describe('Responsive navbar component', function describe() {
       />,
     );
 
-    expect(wrapper.find(NavItem).at(0).props().activeKey).to.eql(2);
-    expect(wrapper.find(NavItem).at(0).text()).to.eql('Style');
-
-    expect(wrapper.get(0).state).to.eql({ wrapping: false, lastWidth: 0 });
+    expect(wrapper.props().activeKey).to.eql(2);
+    expect(wrapper.find('button').at(0).text()).to.eql('Style');
+    expect(wrapper.get(0).state).to.eql(
+      { lastWidth: 0, updateDimenssions: true, lastVisibleItemIndex: -1 });
   });
 
   it('should render combobox correctly', function it() {
     const activeKey = 2;
 
-    const findDOMNode = sinon.stub(ReactDOM, 'findDOMNode').callsFake((ref) => {
-      if (ref._reactInternalInstance._currentElement.ref === 'navitemref0') {
-        return {
-          offsetTop: 1,
-        };
+    const findDOMNode = sinon.stub(ReactDOM, 'findDOMNode').callsFake(() => (
+      {
+        offsetWidth: 400,
       }
-      return {
-        offsetTop: 2,
-      };
-    });
+    ));
 
     const wrapper = mount(
       <ResponsiveNavbar
@@ -62,7 +55,7 @@ describe('Responsive navbar component', function describe() {
     );
 
     // Make the call manually since there's is a timeout in componentDidMount
-    wrapper.get(0).updateDimensions();
+    wrapper.get(0).handleResizeEvent();
 
     expect(wrapper.find('#ocResponsiveNavbarSelect').length).to.eql(1);
     expect(wrapper.find('Select').length).to.eql(1);
@@ -77,46 +70,41 @@ describe('Responsive navbar component', function describe() {
       activeKey,
     });
 
-    navbar.refs = {
-      navitemref0: 'ref0',
-      navitemref1: 'ref1',
-      navitemref2: 'ref2',
-      navitemref3: 'ref3',
-    };
-
-    const refUIData = {
-      ref0: 10,
-      ref1: 10,
-      ref2: 10,
-      ref3: 11,
-    };
-
     // initial state
     expect(navbar.state).to.eql({
-      wrapping: false,
+      updateDimenssions: true,
+      lastVisibleItemIndex: -1,
       lastWidth: 0,
     });
 
-    const findDOMNode = sinon.stub(ReactDOM, 'findDOMNode').callsFake(ref =>
-      ({ offsetTop: refUIData[ref] }),
-    );
+    let offsetWidth = 400;
+    const findDOMNode = sinon.stub(ReactDOM, 'findDOMNode').callsFake(() =>
+          ({ offsetWidth }),
+        );
 
     const navbarStub = sinon.stub(navbar, 'setState').callsFake((state) => {
       navbar.state = state;
     });
 
-    // sets wrapping true, since ref3 offsetTop is different from ref1 offsetTop
-    navbar.updateDimensions();
+    navbar.state.lastWidth = 0;
+    navbar.handleResizeEvent();
+    navbar.componentDidUpdate();
+
+    // sets updateDimenssions false lastVisibleItemIndex should be 2
     expect(navbar.state).to.eql({
-      wrapping: true,
-      lastWidth: 1024,
+      updateDimenssions: false,
+      lastVisibleItemIndex: 2,
     });
 
-    // sets wrapping false, since wrapping is true and difference more that 10
-    navbar.state.lastWidth = 1000;
-    navbar.updateDimensions();
+    navbar.state.lastWidth = 0;
+    offsetWidth = 200;
+    navbar.handleResizeEvent();
+    navbar.componentDidUpdate();
+
+    // sets updateDimenssions false lastVisibleItemIndex should be 1
     expect(navbar.state).to.eql({
-      wrapping: false,
+      updateDimenssions: false,
+      lastVisibleItemIndex: 1,
     });
 
     findDOMNode.restore();


### PR DESCRIPTION
Following functionality added as defined in Feature/86050:

 - Show as many items normally side by side as fits into the free space in screen.
- Rest of the items are shown in the drop down control that is shown as last item in the list.
- When one of the "normal" options are selected show orange highlight line underneath that item and "more" text in drop down control
- When item from drop down control is selected show the text of the selected item in closed drop down control and show the orange underlining under the drop down control.
- Text in drop down should be same font, size and bolding as with the normal options in the navi bar
missing grey underline from unselected items (parametrized, not shown in top navi)
- remove grey background from selected item
- Selected item text color should be normal grey
- Font size when drop down used should be the same as when there is no drop down
- Each navi item has to have min and max width so that too long named do not take the whole navi bar.
