### PR TITLE
activeStep can now be set via URL parameter

### DIFF
--- a/src/wizard/README.md
+++ b/src/wizard/README.md
@@ -25,6 +25,7 @@ save | function | required | Callback function called, when the wizard is saved
 disableSave | bool | false | Disable the Save button
 showPageIndicator | bool | true | Sign of page indicator showing
 steps | array | required | Steps of the wizard
+activeStep | number | 0 | Index of the active step. You can also set activeStep via URL parameter 'step', e.g. http://localhost/wizard/?step=stepId
 
 #### Wizard - steps props
 

--- a/src/wizard/wizard.component.jsx
+++ b/src/wizard/wizard.component.jsx
@@ -17,7 +17,19 @@ export default class Wizard extends React.PureComponent {
   }
 
   componentDidMount() {
-    this.selectPage(undefined, this.props.activeStep);
+    const stepIndex = this.props.activeStep || this.getStepByUrlParam();
+    this.selectPage(null, stepIndex);
+  }
+
+  getStepByUrlParam() {
+    const steps = this.props.steps;
+    let index = null;
+    const param = /step=([^&]+)/.exec(window.location.href)[1];
+
+    if (param && steps && steps.length > 0) {
+      index = steps.findIndex(step => step.id === param);
+    }
+    return index;
   }
 
   selectPage = (event, index) => {
@@ -28,7 +40,7 @@ export default class Wizard extends React.PureComponent {
     this.setState({
       currentStep: index,
     });
-  }
+  };
 
   render() {
     return (


### PR DESCRIPTION
I thought that it would be handy to access the active step via URL parameter ('step'). Referencing a step by an index might not be the best available solution, since the order of the steps may change. So, my solution now uses step's ID to get the index, but I think it would be a safest bet to use an ID as an activeStep prop also.