### PR TITLE
getStepByUrlParam should be placed after componentWillReceiveProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 8.1.0
 * Upgrade - Update react icons 1.3.0
+* Fix - Lint error building npm version
 
 ## 8.0.0
 * Bugfix - Wizard component should now allow to change the active step programmatically.

--- a/src/wizard/wizard.component.jsx
+++ b/src/wizard/wizard.component.jsx
@@ -21,6 +21,12 @@ export default class Wizard extends React.PureComponent {
     this.selectPage(null, stepIndex);
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.activeStep !== this.state.currentStep) {
+      this.selectPage(undefined, nextProps.activeStep);
+    }
+  }
+
   getStepByUrlParam() {
     const steps = this.props.steps;
     let index = null;
@@ -30,12 +36,6 @@ export default class Wizard extends React.PureComponent {
       index = steps.findIndex(step => step.id === param);
     }
     return index;
-  }
-
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.activeStep !== this.state.currentStep) {
-      this.selectPage(undefined, nextProps.activeStep);
-    }
   }
 
   selectPage = (event, index) => {


### PR DESCRIPTION
Error after running npm version: lint "method should be placed after"